### PR TITLE
SkipTableConfig Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Command Option Names | Purpose
   [--required=field1...]                                                                | A list of attributes that are required for an instance of the model
   [--length-validations=field1:MIN-MAX...]                                              | Validations on the length of attributes in a model
   [--table-name=name] | Sets the name of the table in DynamoDB, if different than the model name
+  [--skip-table-config] | Doesn't generate a table config for the model
 
 The included rake task `aws_record:migrate` will run all of the migrations in `app/db/table_config`
 

--- a/lib/generators/aws_record/model/model_generator.rb
+++ b/lib/generators/aws_record/model/model_generator.rb
@@ -27,6 +27,7 @@ module AwsRecord
       class_option :table_config, type: :hash, default: {}, banner: "primary:R-W [SecondaryIndex1:R-W]...", desc: "Declares the r/w units for the model as well as any secondary indexes", :required => true
       class_option :gsi, type: :array, default: [], banner: "name:hkey{field_name}[,rkey{field_name},proj_type{ALL|KEYS_ONLY|INCLUDE}]...", desc: "Allows for the declaration of secondary indexes"
       class_option :table_name, type: :string, banner: "model_table_name"
+      class_option :skip_table_config, type: :boolean, desc: "Disables the generation of a table_config file"
 
       class_option :required, type: :array, default: [], banner: "field1...", desc: "A list of attributes that are required for an instance of the model"
       class_option :length_validations, type: :hash, default: {}, banner: "field1:MIN-MAX...", desc: "Validations on the length of attributes in a model"
@@ -38,7 +39,7 @@ module AwsRecord
       end
 
       def create_table_config
-        template "table_config.rb", File.join("db/table_config", class_path, "#{file_name}_config.rb")
+        template "table_config.rb", File.join("db/table_config", class_path, "#{file_name}_config.rb") unless options.key?(:skip_table_config)
       end
 
       private
@@ -176,7 +177,7 @@ module AwsRecord
 
       def parse_rw_units(name)
         if !options['table_config'].key? name
-          @parse_errors << ArgumentError.new("Please provide a table_config definition for #{name}")
+          @parse_errors << ArgumentError.new("Please provide a table_config definition for #{name}") unless name == "primary" && options.key?(:skip_table_config)
         else
           rw_units = options['table_config'][name]
           return rw_units.gsub(/[,.-]/, ':').split(':').reject { |s| s.empty? }

--- a/spec/aws-record-generator/generators/aws_record/model/model_generator_spec.rb
+++ b/spec/aws-record-generator/generators/aws_record/model/model_generator_spec.rb
@@ -186,6 +186,13 @@ module AwsRecord
         end
       end
 
+      context 'it allows you to disable table_config generation' do
+        it 'allows specification of required validations' do
+          @gen_helper.run_generator ["TestSkipTableConfig", "--skip-table-config"]
+          @gen_helper.assert_not_file(File.expand_path("fixtures/unit/table_config/test_skip_table_config_config.rb"))
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
*Description of changes:*
- [x] Allows the user to skip the generation of the table config file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
